### PR TITLE
Add replace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,9 @@
     "require": {
         "php": ">=5.6.0"
     },
+    "replace": {
+        "robthree/twofactorauth": "self.version"
+    },
     "require-dev": {
         "phpunit/phpunit": "@stable",
         "php-parallel-lint/php-parallel-lint": "^1.2"


### PR DESCRIPTION
This pull request includes a change to the `composer.json` file to add a replacement package definition.

Dependency management:

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R27-R29): Added the `replace` section to specify that the package replaces `robthree/twofactorauth` with its own version.